### PR TITLE
Switch to node 20

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 16.x
+      - name: Set Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ outputs:
   steampipe-version:
     description: The version of Steampipe that was installed.
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
The node 16 runtime is deprecated. Switch to node20.