### PR TITLE
Encourage users to use `actions/checkout@v5`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ See [action.yml](action.yml).
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v5
   - uses: turbot/steampipe-action-setup@v1
     with:
       steampipe-version: 'latest'
@@ -144,7 +144,7 @@ The template must be installed before. It's available in the [templates director
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v5
   - uses: turbot/steampipe-action-setup@v1
     with:
       steampipe-version: 'latest'


### PR DESCRIPTION
This PR updates the version of the [`actions/checkout`](https://github.com/actions/checkout) in the docs.

Note:
- #140 