### PR TITLE
Migrate action runtime from Node.js 20 to Node.js 24

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20.x
+          node-version: 22.x
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - name: Set Node.js 22.x
+      - name: Set Node.js 24.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - name: Install dependencies
         run: npm ci

--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ outputs:
   steampipe-version:
     description: The version of Steampipe that was installed.
 runs:
-  using: node20
+  using: node22
   main: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -22,5 +22,5 @@ outputs:
   steampipe-version:
     description: The version of Steampipe that was installed.
 runs:
-  using: node22
+  using: node24
   main: dist/index.js


### PR DESCRIPTION
## Summary

- Updates `action.yml` to use `node22` runtime (was `node20`, which is deprecated)
- Updates `check-dist.yml` to build with Node.js 22.x to stay in sync

Closes #158

## Test plan

- [ ] Verify `check-dist` workflow passes on this PR
- [ ] Verify `units-test` workflow passes
- [ ] Confirm no deprecation warnings appear in workflow runs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)